### PR TITLE
feature: add docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  db:
+    image: mariadb:10.5.8
+    environment:
+      MYSQL_USER: 'user'
+      MYSQL_PASSWORD: 'for-user-test-only'
+      MYSQL_ROOT_PASSWORD: 'for-root-test-only'
+    ports:
+      - "3306:3306"
+    networks:
+      - default
+networks:
+  default:
+    name: app-network


### PR DESCRIPTION
- add docker compose to replace asking candidate to build a docker image separately and execute docker compose to build the database
- Apple MacOS with M1 cannot use mysql 8.0 or latest